### PR TITLE
Use command-based versions of controllers

### DIFF
--- a/src/main/java/frc/lib/CommandZorroController.java
+++ b/src/main/java/frc/lib/CommandZorroController.java
@@ -1,0 +1,398 @@
+package frc.lib;
+
+import edu.wpi.first.wpilibj.event.EventLoop;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.button.CommandGenericHID;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+
+/**
+ * A version of {@link ZorroController} with {@link Trigger} factories for command-based.
+ *
+ * @see ZorroController
+ */
+@SuppressWarnings("MethodName")
+public class CommandZorroController extends CommandGenericHID {
+  private final ZorroController m_hid;
+
+  /**
+   * Construct an instance of a controller.
+   *
+   * @param port The port index on the Driver Station that the controller is plugged into.
+   */
+  public CommandZorroController(int port) {
+    super(port);
+    m_hid = new ZorroController(port);
+  }
+
+  /**
+   * Get the underlying GenericHID object.
+   *
+   * @return the wrapped GenericHID object
+   */
+  @Override
+  public ZorroController getHID() {
+    return m_hid;
+  }
+
+  /**
+   * Constructs a Trigger instance around the B switch's down signal.
+   *
+   * @return a Trigger instance representing the B switch's down signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger BDown() {
+    return BDown(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the B switch's down signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the B switch's down signal attached
+   *     to the given loop.
+   */
+  public Trigger BDown(EventLoop loop) {
+    return button(ZorroController.Button.kBDown.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the B switch's mid signal.
+   *
+   * @return a Trigger instance representing the B switch's mid signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger BMid() {
+    return BMid(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the B switch's mid signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the B switch's mid signal attached
+   *     to the given loop.
+   */
+  public Trigger BMid(EventLoop loop) {
+    return button(ZorroController.Button.kBMid.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the B switch's up signal.
+   *
+   * @return a Trigger instance representing the B switch's up signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger BUp() {
+    return BUp(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the B switch's up signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the B switch's up signal attached
+   *     to the given loop.
+   */
+  public Trigger BUp(EventLoop loop) {
+    return button(ZorroController.Button.kBUp.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the E switch's down signal.
+   *
+   * @return a Trigger instance representing the E switch's down signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger EDown() {
+    return EDown(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the E switch's down signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the E switch's down signal attached
+   *     to the given loop.
+   */
+  public Trigger EDown(EventLoop loop) {
+    return button(ZorroController.Button.kEDown.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the E switch's up signal.
+   *
+   * @return a Trigger instance representing the E switch's up signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger EUp() {
+    return EUp(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the E switch's up signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the E switch's up signal attached
+   *     to the given loop.
+   */
+  public Trigger EUp(EventLoop loop) {
+    return button(ZorroController.Button.kEUp.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the A button's in signal.
+   *
+   * @return a Trigger instance representing the A button's in signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger AIn() {
+    return AIn(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the A button's in signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the A button's in signal attached
+   *     to the given loop.
+   */
+  public Trigger AIn(EventLoop loop) {
+    return button(ZorroController.Button.kAIn.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the G button's in signal.
+   *
+   * @return a Trigger instance representing the G button's in signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger GIn() {
+    return GIn(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the G button's in signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the G button's in signal attached
+   *     to the given loop.
+   */
+  public Trigger GIn(EventLoop loop) {
+    return button(ZorroController.Button.kGIn.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the C switch's down signal.
+   *
+   * @return a Trigger instance representing the C switch's down signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger CDown() {
+    return CDown(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the C switch's down signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the C switch's down signal attached
+   *     to the given loop.
+   */
+  public Trigger CDown(EventLoop loop) {
+    return button(ZorroController.Button.kCDown.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the C switch's mid signal.
+   *
+   * @return a Trigger instance representing the C switch's mid signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger CMid() {
+    return CMid(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the C switch's mid signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the C switch's mid signal attached
+   *     to the given loop.
+   */
+  public Trigger CMid(EventLoop loop) {
+    return button(ZorroController.Button.kCMid.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the C switch's up signal.
+   *
+   * @return a Trigger instance representing the C switch's up signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger CUp() {
+    return CUp(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the C switch's up signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the C switch's up signal attached
+   *     to the given loop.
+   */
+  public Trigger CUp(EventLoop loop) {
+    return button(ZorroController.Button.kCUp.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the F switch's down signal.
+   *
+   * @return a Trigger instance representing the F switch's down signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger FDown() {
+    return FDown(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the F switch's down signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the F switch's down signal attached
+   *     to the given loop.
+   */
+  public Trigger FDown(EventLoop loop) {
+    return button(ZorroController.Button.kFDown.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the F switch's up signal.
+   *
+   * @return a Trigger instance representing the F switch's up signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger FUp() {
+    return FUp(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the F switch's up signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the F switch's up signal attached
+   *     to the given loop.
+   */
+  public Trigger FUp(EventLoop loop) {
+    return button(ZorroController.Button.kFUp.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the D button's in signal.
+   *
+   * @return a Trigger instance representing the D button's in signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger DIn() {
+    return DIn(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the D button's in signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the D button's in signal attached
+   *     to the given loop.
+   */
+  public Trigger DIn(EventLoop loop) {
+    return button(ZorroController.Button.kDIn.value, loop);
+  }
+
+  /**
+   * Constructs a Trigger instance around the H button's in signal.
+   *
+   * @return a Trigger instance representing the H button's in signal attached
+   *     to the {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #a(EventLoop)
+   */
+  public Trigger HIn() {
+    return HIn(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance around the H button's in signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a Trigger instance representing the H button's in signal attached
+   *     to the given loop.
+   */
+  public Trigger HIn(EventLoop loop) {
+    return button(ZorroController.Button.kHIn.value, loop);
+  }
+
+  /**
+   * Get the X axis value of controller's left stick.
+   *
+   * @return The axis value.
+   */
+  public double getLeftXAxis() {
+    return m_hid.getLeftXAxis();
+  }
+
+  /**
+   * Get the X axis value of controller's right stick.
+   *
+   * @return The axis value.
+   */
+  public double getRightXAxis() {
+    return m_hid.getRightXAxis();
+  }
+
+  /**
+   * Get the Y axis value of controller's left stick.
+   *
+   * @return The axis value.
+   */
+  public double getLeftYAxis() {
+    return m_hid.getLeftYAxis();
+  }
+
+  /**
+   * Get the Y axis value of controller's right stick.
+   *
+   * @return The axis value.
+   */
+  public double getRightYAxis() {
+    return m_hid.getRightYAxis();
+  }
+
+  /**
+   * Get the axis value of controller's left dial.
+   *
+   * @return The axis value.
+   */
+  public double getLeftDial() {
+    return m_hid.getLeftDial();
+  }
+
+  /**
+   * Get the axis value of controller's right dial.
+   *
+   * @return The axis value.
+   */
+  public double getRightDial() {
+    return m_hid.getRightDial();
+  }
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,16 +6,15 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.lib.AllianceSelector;
 import frc.lib.AutoOption;
 import frc.lib.AutoSelector;
+import frc.lib.CommandZorroController;
 import frc.lib.ControllerPatroller;
-import frc.lib.ZorroController;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
@@ -34,8 +33,8 @@ public class Robot extends TimedRobot {
   private final AutoSelector m_autoSelector;
   private final Drivetrain m_swerve;
 
-  private ZorroController m_driver;
-  private XboxController m_operator;
+  private CommandZorroController m_driver;
+  private CommandXboxController m_operator;
 
   private int m_usb_check_delay = OIConstants.kUSBCheckNumLoops;
 
@@ -71,8 +70,8 @@ public class Robot extends TimedRobot {
   @Override
   public void robotPeriodic() {
     CommandScheduler.getInstance().run();
-    SmartDashboard.putData(m_driver);
-    SmartDashboard.putData(m_operator);
+    SmartDashboard.putData(m_driver.getHID());
+    SmartDashboard.putData(m_operator.getHID());
     SmartDashboard.putData(m_powerDistribution);
   }
 
@@ -126,7 +125,7 @@ public class Robot extends TimedRobot {
 
   private void configureDefaultCommands() {
     m_swerve.setDefaultCommand(
-        new ZorroDriveCommand(m_swerve, DriveConstants.kDriveKinematics, m_driver));
+        new ZorroDriveCommand(m_swerve, DriveConstants.kDriveKinematics, m_driver.getHID()));
   }
 
   public void configureButtonBindings() {
@@ -138,8 +137,8 @@ public class Robot extends TimedRobot {
 
     // We use two different types of controllers - Joystick & XboxController.
     // Create objects of the specific types.
-    m_driver = new ZorroController(cp.findDriverPort());
-    m_operator = new XboxController(cp.findOperatorPort());
+    m_driver = new CommandZorroController(cp.findDriverPort());
+    m_operator = new CommandXboxController(cp.findOperatorPort());
 
     configureDriverButtonBindings();
     configureOperatorButtonBindings();
@@ -149,7 +148,7 @@ public class Robot extends TimedRobot {
   private void configureDriverButtonBindings() {
 
     // Reset heading
-    new JoystickButton(m_driver, ZorroController.Button.kHIn.value)
+    m_driver.HIn()
         .onTrue(new InstantCommand(() -> m_swerve.resetHeading())
         .ignoringDisable(true));
 


### PR DESCRIPTION
Use [trigger factories](https://docs.wpilib.org/en/latest/docs/software/commandbased/binding-commands-to-triggers.html#hid-factories) in the command-based versions of the HID classes to return a Trigger for binding commands

