### PR TITLE
Convert cameras to subsystems, add vision-only pose estimate for pose-seek

### DIFF
--- a/src/main/java/frc/robot/LEDs/LEDs.java
+++ b/src/main/java/frc/robot/LEDs/LEDs.java
@@ -372,18 +372,6 @@ public class LEDs extends SubsystemBase {
   }
 
   /**
-   * Create a command to display pose seeking information on the LEDs.
-   *
-   * @param targetPoseSupplier provides the target pose
-   * @param currentPoseSupplier provides the current pose
-   * @return a command to display pose seeking information
-   */
-  public Command createPoseSeekingCommand(
-      Supplier<Pose2d> targetPoseSupplier, Supplier<Pose2d> currentPoseSupplier) {
-    return newCommand(() -> displayPoseSeek(currentPoseSupplier.get(), targetPoseSupplier.get()));
-  }
-
-  /**
    * Create a pattern to display stacked blocks on the left and right strips.
    *
    * @return a command to display stacked blocks
@@ -446,8 +434,10 @@ public class LEDs extends SubsystemBase {
          */
         auto -> {
           var hasInitialPose = auto.getInitialPose().isPresent();
-          if (hasInitialPose) {
+          if (hasInitialPose && currentPose != null) {
             displayPoseSeek(currentPose, auto.getInitialPose().get());
+          } else if (currentPose == null) {
+            fill(Color.kDarkGray, Segments.ALL);
           }
           displayAutoSelection(
               auto.getAllianceColor(), auto.getOptionNumber(), agreement, hasInitialPose);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -137,7 +137,10 @@ public class Robot extends TimedRobot {
     leds.replaceDefaultCommandImmediately(
         leds.createAutoOptionDisplayCommand(
                 autoSelector,
-                () -> swerve.getPose(),
+                () ->
+                    vision.getEstimatedGlobalPose().isPresent()
+                        ? vision.getEstimatedGlobalPose().get().estimatedPose.toPose2d()
+                        : null,
                 allianceSelector.getAgreementInAllianceColor())
             .ignoringDisable(true));
 

--- a/src/main/java/frc/robot/vision/Camera.java
+++ b/src/main/java/frc/robot/vision/Camera.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj2.command.Subsystem;
 import frc.robot.Constants;
 import java.util.List;
 import java.util.Optional;
@@ -18,7 +19,7 @@ import org.photonvision.PhotonPoseEstimator;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
-public enum Camera {
+public enum Camera implements Subsystem {
   FrontRight("OV2311_TH_8", new Translation3d(0.248, -0.318, 0.513), new Rotation3d(0.0, 0.0, 0.0)),
   FrontLeft(
       "OV2311_TH_5", new Translation3d(0.222, 0.331, 0.513), new Rotation3d(0.0, 0, Math.PI / 2.0)),
@@ -32,13 +33,16 @@ public enum Camera {
   public final String name;
   public final Transform3d transform;
   public final PhotonCamera device;
-  public PhotonPoseEstimator pose;
+
+  private Optional<EstimatedRobotPose> pose;
+  private final PhotonPoseEstimator poseEstimator;
   private Matrix<N3, N1> curStdDevs;
 
   private Camera(String name, Translation3d translation, Rotation3d rotation) {
     this.name = name;
     this.transform = new Transform3d(translation, rotation);
     this.device = new PhotonCamera(name);
+    this.pose = Optional.empty();
 
     // AprilTagFieldLayout tagLayout;
     // try {
@@ -51,13 +55,30 @@ public enum Camera {
     AprilTagFieldLayout tagLayout =
         AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeAndyMark);
 
-    this.pose =
+    this.poseEstimator =
         new PhotonPoseEstimator(tagLayout, PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, transform);
+    register();
+  }
+
+  /** Updates the pose estimate for this camera */
+  @Override
+  public void periodic() {
+    device
+        .getAllUnreadResults()
+        .forEach(
+            change -> {
+              pose = poseEstimator.update(change);
+              updateEstimationStdDevs(pose, change.getTargets());
+            });
+  }
+
+  @Override
+  public String getName() {
+    return "Camera." + toString();
   }
 
   /**
-   * The latest estimated robot pose on the field from vision data. This may be empty. This should
-   * only be called once per loop.
+   * The latest estimated robot pose on the field from vision data. This may be empty.
    *
    * <p>Also includes updates for the standard deviations, which can (optionally) be retrieved with
    * {@link getEstimationStdDevs}
@@ -66,12 +87,17 @@ public enum Camera {
    *     used for estimation.
    */
   public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
-    Optional<EstimatedRobotPose> est = Optional.empty();
-    for (var change : device.getAllUnreadResults()) {
-      est = pose.update(change);
-      updateEstimationStdDevs(est, change.getTargets());
-    }
-    return est;
+    return pose;
+  }
+
+  /**
+   * Returns the latest standard deviations of the estimated pose from {@link
+   * #getEstimatedGlobalPose()}, for use with {@link
+   * edu.wpi.first.math.estimator.SwerveDrivePoseEstimator SwerveDrivePoseEstimator}. This should
+   * only be used when there are targets visible.
+   */
+  public Matrix<N3, N1> getEstimationStdDevs() {
+    return curStdDevs;
   }
 
   /**
@@ -95,7 +121,7 @@ public enum Camera {
 
       // Precalculation - see how many tags we found, and calculate an average-distance metric
       for (var tgt : targets) {
-        var tagPose = pose.getFieldTags().getTagPose(tgt.getFiducialId());
+        var tagPose = poseEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
         if (tagPose.isEmpty()) continue;
         numTags++;
         avgDist +=
@@ -121,15 +147,5 @@ public enum Camera {
         curStdDevs = estStdDevs;
       }
     }
-  }
-
-  /**
-   * Returns the latest standard deviations of the estimated pose from {@link
-   * #getEstimatedGlobalPose()}, for use with {@link
-   * edu.wpi.first.math.estimator.SwerveDrivePoseEstimator SwerveDrivePoseEstimator}. This should
-   * only be used when there are targets visible.
-   */
-  public Matrix<N3, N1> getEstimationStdDevs() {
-    return curStdDevs;
   }
 }

--- a/src/main/java/frc/robot/vision/Vision.java
+++ b/src/main/java/frc/robot/vision/Vision.java
@@ -3,12 +3,29 @@ package frc.robot.vision;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.photonvision.EstimatedRobotPose;
 
-public class Vision {
+public class Vision extends SubsystemBase {
+
+  /** Choose the pose estimate with the lowest maximum stdev. */
+  public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
+    return Arrays.stream(Camera.values())
+        .sorted(
+            (lhs, rhs) ->
+                (int)
+                    Math.signum(
+                        lhs.getEstimationStdDevs().max() - rhs.getEstimationStdDevs().max()))
+        .map(cam -> cam.getEstimatedGlobalPose())
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst();
+  }
+
   public record EstimatedPoseWithStdevs(
       EstimatedRobotPose pose, Matrix<N3, N1> stdev, String name) {}
 


### PR DESCRIPTION
Each `Camera` is now its own subsystem.  In `periodic()`, pipeline results are applied to each `Camera`'s `PhotonPoseEstimator`, and its current `EstimatedRobotPose` is calculated.  This pose is also used by the `SwerveDrivePoseEstimator` to correct odometry drift as before.  The pose-seek logic now uses `Vision.getEstimatedGlobalPose()`, which returns the camera-only pose estimate that has the lowest maximum error component.

Needs testing before merging into main.