### PR TITLE
Reset ProfiledPIDControllers at the same time that control begins

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -44,8 +44,6 @@ import frc.robot.drivetrain.commands.ZorroDriveCommand;
 import frc.robot.elevator.AlgaeRoller;
 import frc.robot.elevator.CoralRoller;
 import frc.robot.elevator.Elevator;
-import frc.robot.elevator.ElevatorConstants.AlgaeWristConstants.AlgaeWristState;
-import frc.robot.elevator.ElevatorConstants.CoralWristConstants.CoralWristState;
 import frc.robot.elevator.Lifter;
 import frc.robot.vision.Vision;
 import frc.util.Gamepiece;
@@ -171,8 +169,6 @@ public class Robot extends TimedRobot {
   public void autonomousInit() {
     autoSelector.scheduleAuto();
     climber.lockRatchet();
-    elevator.getCoralWrist().createSetAngleCommand(CoralWristState.Initial).schedule();
-    elevator.getAlgaeWrist().createSetAngleCommand(AlgaeWristState.Initial).schedule();
     lifter.setDefaultCommand(lifter.createRemainAtCurrentHeightCommand());
     leds.replaceDefaultCommandImmediately(
         leds.createStandardDisplayCommand(algaeModeSupplier, gamepieceSupplier));
@@ -188,14 +184,10 @@ public class Robot extends TimedRobot {
     swerve.resetHeadingOffset();
     climber.resetEncoder();
     climber.lockRatchet();
-    elevator.resetPositionControllers();
     lifter.setDefaultCommand(lifter.createJoystickControlCommand(operator.getHID()));
-    // lifter.setDefaultCommand(lifter.createJoystickVoltageCommand(operator.getHID()));
     leds.replaceDefaultCommandImmediately(
         leds.createStandardDisplayCommand(algaeModeSupplier, gamepieceSupplier));
 
-    elevator.getCoralWrist().createSetAngleCommand(CoralWristState.Initial).schedule();
-    elevator.getAlgaeWrist().createSetAngleCommand(AlgaeWristState.Initial).schedule();
     // Test wrist feedforwards
     // algaeWrist.setDefaultCommand(algaeWrist.createJoystickControlCommand(operator.getHID()));
     // coralWrist.setDefaultCommand(coralWrist.createJoystickControlCommand(operator.getHID()));

--- a/src/main/java/frc/robot/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/drivetrain/Drivetrain.java
@@ -21,6 +21,8 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Dimensionless;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.AutoConstants.RotationControllerGains;
 import frc.robot.Constants.AutoConstants.TranslationControllerGains;
@@ -181,8 +183,8 @@ public class Drivetrain extends SubsystemBase {
     return headingOffset;
   }
 
-  public void resetHeadingOffset() {
-    headingOffset = new Rotation2d();
+  public Command resetHeadingOffset() {
+    return new InstantCommand(() -> this.headingOffset = new Rotation2d());
   }
 
   public void setHeadingOffset() {

--- a/src/main/java/frc/robot/elevator/AlgaeWrist.java
+++ b/src/main/java/frc/robot/elevator/AlgaeWrist.java
@@ -147,7 +147,8 @@ public class AlgaeWrist extends SubsystemBase {
         // initialize
         () -> {
           if (targetState == AlgaeWristState.Initial) {
-            feedback.setGoal(encoder.getPosition());
+            targetState = AlgaeWristState.CoralMode;
+            feedback.setGoal(targetState.angle.in(Radians));
             // Users should call reset() when they first start running the controller to avoid
             // unwanted behavior.
             resetController();

--- a/src/main/java/frc/robot/elevator/AlgaeWrist.java
+++ b/src/main/java/frc/robot/elevator/AlgaeWrist.java
@@ -106,7 +106,7 @@ public class AlgaeWrist extends SubsystemBase {
     return Radians.of(feedback.getSetpoint().position);
   }
 
-  public void resetController() {
+  private void resetController() {
     feedback.reset(encoder.getPosition(), encoder.getVelocity());
   }
 
@@ -145,9 +145,11 @@ public class AlgaeWrist extends SubsystemBase {
     return new FunctionalCommand(
         // initialize
         () -> {
-          if (targetState == AlgaeWristState.Unknown) {
-            targetState = AlgaeWristState.CoralMode;
-            feedback.setGoal(targetState.angle.in(Radians));
+          if (targetState == AlgaeWristState.Initial) {
+            feedback.setGoal(encoder.getPosition());
+            // Users should call reset() when they first start running the controller to avoid
+            // unwanted behavior.
+            resetController();
           }
         },
         // execute

--- a/src/main/java/frc/robot/elevator/AlgaeWrist.java
+++ b/src/main/java/frc/robot/elevator/AlgaeWrist.java
@@ -106,7 +106,7 @@ public class AlgaeWrist extends SubsystemBase {
     return Radians.of(feedback.getSetpoint().position);
   }
 
-  private void resetController() {
+  public void resetController() {
     feedback.reset(encoder.getPosition(), encoder.getVelocity());
   }
 

--- a/src/main/java/frc/robot/elevator/CoralWrist.java
+++ b/src/main/java/frc/robot/elevator/CoralWrist.java
@@ -109,7 +109,7 @@ public class CoralWrist extends SubsystemBase {
     return Radians.of(feedback.getSetpoint().position);
   }
 
-  public void resetController() {
+  private void resetController() {
     feedback.reset(encoder.getPosition(), encoder.getVelocity());
   }
 
@@ -156,7 +156,12 @@ public class CoralWrist extends SubsystemBase {
     return new FunctionalCommand(
         // initialize
         () -> {
-          if (targetState == CoralWristState.Unknown) feedback.setGoal(encoder.getPosition());
+          if (targetState == CoralWristState.Initial) {
+            feedback.setGoal(encoder.getPosition());
+            // Users should call reset() when they first start running the controller to avoid
+            // unwanted behavior.
+            resetController();
+          }
         },
         // execute
         () -> control(),

--- a/src/main/java/frc/robot/elevator/CoralWrist.java
+++ b/src/main/java/frc/robot/elevator/CoralWrist.java
@@ -109,7 +109,7 @@ public class CoralWrist extends SubsystemBase {
     return Radians.of(feedback.getSetpoint().position);
   }
 
-  private void resetController() {
+  public void resetController() {
     feedback.reset(encoder.getPosition(), encoder.getVelocity());
   }
 

--- a/src/main/java/frc/robot/elevator/Elevator.java
+++ b/src/main/java/frc/robot/elevator/Elevator.java
@@ -2,6 +2,7 @@ package frc.robot.elevator;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.elevator.ElevatorConstants.AlgaeWristConstants.AlgaeWristState;
 import frc.robot.elevator.ElevatorConstants.CoralWristConstants.CoralWristState;
 import frc.robot.elevator.ElevatorConstants.LifterConstants.LifterState;
@@ -36,11 +37,14 @@ public class Elevator {
     return algaeWrist;
   }
 
-  // public void resetPositionControllers() {
-  //   lifter.resetController();
-  //   coralWrist.resetController();
-  //   algaeWrist.resetController();
-  // }
+  public Command resetPositionControllers() {
+    return new InstantCommand(
+        () -> {
+          lifter.resetController();
+          coralWrist.resetController();
+          algaeWrist.resetController();
+        });
+  }
 
   public Command coralL4PositionCG() {
     return Commands.parallel(

--- a/src/main/java/frc/robot/elevator/Elevator.java
+++ b/src/main/java/frc/robot/elevator/Elevator.java
@@ -36,11 +36,11 @@ public class Elevator {
     return algaeWrist;
   }
 
-  public void resetPositionControllers() {
-    lifter.resetController();
-    coralWrist.resetController();
-    algaeWrist.resetController();
-  }
+  // public void resetPositionControllers() {
+  //   lifter.resetController();
+  //   coralWrist.resetController();
+  //   algaeWrist.resetController();
+  // }
 
   public Command coralL4PositionCG() {
     return Commands.parallel(

--- a/src/main/java/frc/robot/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/elevator/ElevatorConstants.java
@@ -57,7 +57,7 @@ public class ElevatorConstants {
     }
 
     public static enum LifterState {
-      Unknown(0.0),
+      Initial(0.0),
       Min(0.0),
       AlgaeIntakeFloor(1.0),
       EncoderReset(0.36),
@@ -142,7 +142,6 @@ public class ElevatorConstants {
 
     public static enum CoralWristState {
       Initial(90),
-      Unknown(90),
       Min(15),
       Max(135),
       L1(125),
@@ -227,7 +226,6 @@ public class ElevatorConstants {
 
     public static enum AlgaeWristState {
       Initial(80),
-      Unknown(90),
       Floor(0),
       Min(-10),
       Max(95),

--- a/src/main/java/frc/robot/elevator/Lifter.java
+++ b/src/main/java/frc/robot/elevator/Lifter.java
@@ -130,7 +130,7 @@ public class Lifter extends SubsystemBase {
     return getCurrentHeight().div(LifterState.Max.height);
   }
 
-  private void resetController() {
+  public void resetController() {
     feedback.reset(encoder.getPosition());
     feedback.setGoal(encoder.getPosition());
   }


### PR DESCRIPTION
Intended to prevent the unwanted wrist movement that has been seen immediately after enabling the robot in auto and teleop.

Needs testing before merge.