### PR TITLE
Increase voltage setpoint for holding algae

### DIFF
--- a/src/main/java/frc/robot/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/elevator/ElevatorConstants.java
@@ -176,7 +176,7 @@ public class ElevatorConstants {
     public static final double kVelocityConversionFactor = kPositionConversionFactor / 60.0;
 
     public static final Voltage kIntakeVoltage = Volts.of(5.0);
-    public static final Voltage kHoldVoltage = Volts.of(1.0);
+    public static final Voltage kHoldVoltage = Volts.of(2.0);
     public static final Voltage kOuttakeVoltage = kIntakeVoltage.unaryMinus();
   }
 


### PR DESCRIPTION
Setpoint was 1V, which we observed causes a ~5A steady-state current draw when holding an algae. We can safely increase this based on [REV's locked rotor testing](https://www.revrobotics.com/neo-550-brushless-motor-locked-rotor-testing/).

![image](https://github.com/user-attachments/assets/7fdeb45b-4554-4484-ab70-cccb76dd84d5)
