### PR TITLE
Match actual coral wrist gearing

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -21,6 +21,22 @@ import edu.wpi.first.wpilibj.util.Color;
 
 public final class Constants {
 
+  public static final class MotorConstants {
+    public static final class NEOConstants {
+      public static final AngularVelocity kFreeSpeed = RPM.of(5676);
+      public static final int kDefaultCurrentLimit = 80;
+    }
+
+    public static final class NEO550Constants {
+      public static final AngularVelocity kFreeSpeed = RPM.of(11000);
+      public static final int kDefaultCurrentLimit = 30;
+    }
+
+    public static final class NEOVortexConstants {
+      public static final int kDefaultCurrentLimit = 80;
+    }
+  }
+
   public static final class VisionConstants {
     public static final String kAprilTagLayoutPath =
         Filesystem.getDeployDirectory() + "/" + "stemgym.json";
@@ -35,9 +51,6 @@ public final class Constants {
   public static final class RobotConstants {
     public static final double kNominalVoltage = 12.0;
     public static final Time kPeriod = Seconds.of(TimedRobot.kDefaultPeriod);
-
-    public static final int kDefaultNEOCurrentLimit = 80;
-    public static final int kDefaultNEO550CurretnLimit = 30;
   }
 
   public static final class DriveConstants {
@@ -159,10 +172,6 @@ public final class Constants {
   }
 
   public static final class ModuleConstants {
-
-    public static final int kDriveMotorCurrentLimit = 80;
-    public static final int kTurningMotorCurrentLimit = 80;
-
     public static final class DriveControllerGains {
       public static final double kP = 0.1; // 2023 Competition Robot
       public static final double kI = 0.0; // 2023 Competition Robot
@@ -261,8 +270,6 @@ public final class Constants {
 
   public static final class ClimberConstants {
     public static final int kClimberPort = 17;
-    public static final int kClimberCurrentLimit = 80;
-
     public static final int kRatchetServoPort = 1;
     public static final double kEngagedPosition = 0 / 1024.0;
     public static final double kDisengedPosition = 1024.0 / 1024.0;

--- a/src/main/java/frc/robot/climber/Climber.java
+++ b/src/main/java/frc/robot/climber/Climber.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ClimberConstants;
+import frc.robot.Constants.MotorConstants.NEOVortexConstants;
 import frc.robot.Constants.RobotConstants;
 
 public class Climber extends SubsystemBase {
@@ -36,7 +37,7 @@ public class Climber extends SubsystemBase {
         .voltageCompensation(RobotConstants.kNominalVoltage)
         .inverted(false)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(ClimberConstants.kClimberCurrentLimit);
+        .smartCurrentLimit(NEOVortexConstants.kDefaultCurrentLimit);
 
     motorConfig.closedLoop
         .p(ClimberConstants.kP)

--- a/src/main/java/frc/robot/drivetrain/SwerveModule.java
+++ b/src/main/java/frc/robot/drivetrain/SwerveModule.java
@@ -23,6 +23,8 @@ import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.ModuleConstants;
 import frc.robot.Constants.ModuleConstants.DriveControllerGains;
 import frc.robot.Constants.ModuleConstants.TurningControllerGains;
+import frc.robot.Constants.MotorConstants.NEOConstants;
+import frc.robot.Constants.MotorConstants.NEOVortexConstants;
 import frc.robot.Constants.RobotConstants;
 
 public enum SwerveModule {
@@ -68,13 +70,13 @@ public enum SwerveModule {
       .voltageCompensation(RobotConstants.kNominalVoltage)
       .inverted(false)
       .idleMode(IdleMode.kCoast)
-      .smartCurrentLimit(ModuleConstants.kDriveMotorCurrentLimit);
+      .smartCurrentLimit(NEOVortexConstants.kDefaultCurrentLimit);
 
     m_turningMotorConfig
         .voltageCompensation(RobotConstants.kNominalVoltage)
         .inverted(false)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(ModuleConstants.kTurningMotorCurrentLimit);
+        .smartCurrentLimit(NEOConstants.kDefaultCurrentLimit);
 
     m_driveMotorConfig.closedLoop
         .p(DriveControllerGains.kP)

--- a/src/main/java/frc/robot/elevator/AlgaeRoller.java
+++ b/src/main/java/frc/robot/elevator/AlgaeRoller.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.MotorConstants.NEO550Constants;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.elevator.ElevatorConstants.AlgaeRollerConstants;
 
@@ -36,7 +37,7 @@ public class AlgaeRoller extends SubsystemBase {
     config
         .voltageCompensation(RobotConstants.kNominalVoltage)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(RobotConstants.kDefaultNEO550CurretnLimit)
+        .smartCurrentLimit(NEO550Constants.kDefaultCurrentLimit)
         .inverted(false);
 
     config.limitSwitch

--- a/src/main/java/frc/robot/elevator/AlgaeWrist.java
+++ b/src/main/java/frc/robot/elevator/AlgaeWrist.java
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.MotorConstants.NEOConstants;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.elevator.ElevatorConstants.AlgaeWristConstants;
 import frc.robot.elevator.ElevatorConstants.AlgaeWristConstants.AlgaeWristState;
@@ -48,7 +49,7 @@ public class AlgaeWrist extends SubsystemBase {
     config
         .inverted(false)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(RobotConstants.kDefaultNEOCurrentLimit)
+        .smartCurrentLimit(NEOConstants.kDefaultCurrentLimit)
         .voltageCompensation(RobotConstants.kNominalVoltage);
     
     config.closedLoop

--- a/src/main/java/frc/robot/elevator/CoralRoller.java
+++ b/src/main/java/frc/robot/elevator/CoralRoller.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.MotorConstants.NEO550Constants;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.elevator.ElevatorConstants.CoralRollerConstants;
 
@@ -31,7 +32,7 @@ public class CoralRoller extends SubsystemBase {
     config
         .voltageCompensation(RobotConstants.kNominalVoltage)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(RobotConstants.kDefaultNEO550CurretnLimit)
+        .smartCurrentLimit(NEO550Constants.kDefaultCurrentLimit)
         .inverted(true);
 
     config.limitSwitch

--- a/src/main/java/frc/robot/elevator/CoralWrist.java
+++ b/src/main/java/frc/robot/elevator/CoralWrist.java
@@ -23,6 +23,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.MotorConstants.NEO550Constants;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.elevator.ElevatorConstants.CoralWristConstants;
 import frc.robot.elevator.ElevatorConstants.CoralWristConstants.CoralWristState;
@@ -49,7 +50,7 @@ public class CoralWrist extends SubsystemBase {
     config
         .inverted(true)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(RobotConstants.kDefaultNEO550CurretnLimit)
+        .smartCurrentLimit(NEO550Constants.kDefaultCurrentLimit)
         .voltageCompensation(RobotConstants.kNominalVoltage);
 
     config.closedLoop

--- a/src/main/java/frc/robot/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/elevator/ElevatorConstants.java
@@ -11,6 +11,8 @@ import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Voltage;
+import frc.robot.Constants.MotorConstants.NEO550Constants;
+import frc.robot.Constants.MotorConstants.NEOConstants;
 
 public class ElevatorConstants {
 
@@ -25,7 +27,8 @@ public class ElevatorConstants {
     private static final Distance sprocketPitchDiameter = Inches.of(1.7567);
     public static final Distance kPositionConversionFactor =
         sprocketPitchDiameter.times(Math.PI).times(gearRatioMotorToMechanism);
-    private static final double maxMotorVelocityRadPerSec = RPM.of(5676).in(RadiansPerSecond);
+    private static final double maxMotorVelocityRadPerSec =
+        NEOConstants.kFreeSpeed.in(RadiansPerSecond);
     private static final LinearVelocity maxTheoreticalVelocity =
         InchesPerSecond.of(maxMotorVelocityRadPerSec * kPositionConversionFactor.in(Inches));
 
@@ -100,11 +103,11 @@ public class ElevatorConstants {
   public static final class CoralWristConstants {
     public static final int kMotorPort = 22;
 
-    private static final double gearRatioMotortoEncoder = 1.0 / 5.0;
+    private static final double gearRatioMotortoEncoder =
+        1.0 / 10.0; // VersaPlanetary gearbox, changed 3/7/2025
     private static final double gearRatioEncoderToArm = 24.0 / 42.0;
-    private static final AngularVelocity maxMotorVelocity = RPM.of(5000);
     private static final AngularVelocity maxArmVelocityTheoretical =
-        maxMotorVelocity.times(gearRatioMotortoEncoder).times(gearRatioEncoderToArm);
+        NEO550Constants.kFreeSpeed.times(gearRatioMotortoEncoder).times(gearRatioEncoderToArm);
     private static final AngularVelocity maxArmVelocityConstraint = DegreesPerSecond.of(90.0);
     private static final AngularAcceleration maxArmAcceleration =
         DegreesPerSecondPerSecond.of(180.0);
@@ -131,8 +134,10 @@ public class ElevatorConstants {
     public static final AngularVelocity kVelocityConversionFactor =
         Rotations.of(gearRatioEncoderToArm).per(Minute);
 
-    public static final double kG = 0.55; // Found empirically 2/22/2025
-    public static final double kS = 0.15; // Found empirically 2/22/2025
+    // Found empirically 2/22/2025, then halved when gearing was doubled 3/7/2025
+    public static final double kG = 0.55;
+    public static final double kS = 0.15;
+
     public static final double kV = (12.0 - kS) / maxArmVelocityTheoretical.in(RadiansPerSecond);
 
     public static final double kP = 6.0;
@@ -186,9 +191,8 @@ public class ElevatorConstants {
     private static final double gearRatioMotortoEncoder =
         (1.0 / 5.0) * (18.0 / 36.0); // 5:1 for motor, 36:18 for belt
     private static final double gearRatioEncoderToArm = 1.0;
-    private static final AngularVelocity maxMotorVelocity = RPM.of(5676);
     private static final AngularVelocity maxArmVelocityTheoretical =
-        maxMotorVelocity.times(gearRatioMotortoEncoder).times(gearRatioEncoderToArm);
+        NEOConstants.kFreeSpeed.times(gearRatioMotortoEncoder).times(gearRatioEncoderToArm);
     private static final AngularVelocity maxArmVelocityConstraint = DegreesPerSecond.of(180.0);
     private static final AngularAcceleration maxArmAcceleration =
         DegreesPerSecondPerSecond.of(180.0);

--- a/src/main/java/frc/robot/elevator/Lifter.java
+++ b/src/main/java/frc/robot/elevator/Lifter.java
@@ -25,6 +25,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.MotorConstants.NEOConstants;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.elevator.ElevatorConstants.LifterConstants;
 import frc.robot.elevator.ElevatorConstants.LifterConstants.LifterController;
@@ -63,7 +64,7 @@ public class Lifter extends SubsystemBase {
     globalConfig
         .voltageCompensation(RobotConstants.kNominalVoltage)
         .idleMode(IdleMode.kBrake)
-        .smartCurrentLimit(RobotConstants.kDefaultNEOCurrentLimit)
+        .smartCurrentLimit(NEOConstants.kDefaultCurrentLimit)
         .inverted(false);
 
     leaderConfig


### PR DESCRIPTION
- Correct coral wrist gearing to match changes made Friday 3/7/2025
- Make offsetting changes to maintain the kV term that was found to work on 3/8/2025
- Reorganize motor constants throughout the repo